### PR TITLE
Improve mobile UX with touch controls and audio fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,22 @@
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    /* Mobile-specific touch behavior fixes */
+    html, body {
+      overscroll-behavior: none; /* Prevent pull-to-refresh and bounce */
+      touch-action: pan-x pan-y; /* Allow scrolling but prevent other gestures */
+      -webkit-user-select: none; /* Prevent text selection on iOS */
+      user-select: none; /* Prevent text selection */
+      -webkit-tap-highlight-color: transparent; /* Remove tap highlight */
+    }
+
+    /* Prevent text selection on game elements */
+    #root {
+      -webkit-user-select: none;
+      user-select: none;
+    }
+  </style>
 </head>
 
 <body class="bg-gray-900">
@@ -509,6 +525,14 @@
       large: { width: 1200, height: 900, label: 'Large' }
     };
 
+    // Canvas sizing constants
+    const CANVAS_SIZING = {
+      WINDOW_PADDING: 20, // Horizontal padding from window edges
+      VERTICAL_SPACING_DESKTOP: 200, // Space for UI above/below canvas on desktop
+      VERTICAL_SPACING_MOBILE: 250, // Extra space for touch controls on mobile
+      AUDIO_UNLOCK_VOLUME: 0, // Silent volume for mobile audio unlock
+    };
+
     // ============================================================================
     // COLLISION RESPONSE FUNCTIONS
     // ============================================================================
@@ -647,6 +671,29 @@
         });
 
         soundsRef.current = sounds;
+
+        // Mobile audio unlock: play silent audio on first touch to enable sound
+        const unlockAudio = () => {
+          Object.values(sounds).forEach(audio => {
+            const clone = audio.cloneNode();
+            clone.volume = CANVAS_SIZING.AUDIO_UNLOCK_VOLUME;
+            clone.play().then(() => clone.pause()).catch(() => {});
+          });
+          // Remove listeners after first unlock
+          document.removeEventListener('touchstart', unlockAudio);
+          document.removeEventListener('touchend', unlockAudio);
+        };
+
+        // Only add unlock for touch devices
+        if ('ontouchstart' in window) {
+          document.addEventListener('touchstart', unlockAudio, { once: true });
+          document.addEventListener('touchend', unlockAudio, { once: true });
+        }
+
+        return () => {
+          document.removeEventListener('touchstart', unlockAudio);
+          document.removeEventListener('touchend', unlockAudio);
+        };
       }, []);
 
       // Detect touch device and responsive canvas sizing
@@ -657,8 +704,12 @@
 
         const updateCanvasSize = () => {
           const baseScale = VIEWPORT_SCALES[viewportScale];
-          const maxWidth = Math.min(window.innerWidth - 20, baseScale.width);
-          const maxHeight = Math.min(window.innerHeight - 200, baseScale.height);
+          // Adjust spacing based on device type
+          const verticalSpacing = hasTouchSupport
+            ? CANVAS_SIZING.VERTICAL_SPACING_MOBILE
+            : CANVAS_SIZING.VERTICAL_SPACING_DESKTOP;
+          const maxWidth = Math.min(window.innerWidth - CANVAS_SIZING.WINDOW_PADDING, baseScale.width);
+          const maxHeight = Math.min(window.innerHeight - verticalSpacing, baseScale.height);
           const aspectRatio = baseScale.width / baseScale.height;
 
           let width = maxWidth;
@@ -2954,6 +3005,7 @@
                   {/* Virtual Joystick Area (left side) */}
                   <div
                     className="absolute left-4 bottom-4 w-32 h-32 pointer-events-auto"
+                    style={{ touchAction: 'none' }}
                     onTouchStart={(e) => {
                       e.preventDefault();
                       const touch = e.touches[0];
@@ -2998,6 +3050,7 @@
                   {/* Weapon Switch Button */}
                   <div
                     className="absolute right-4 top-4 w-16 h-16 pointer-events-auto"
+                    style={{ touchAction: 'none' }}
                     onTouchStart={(e) => {
                       e.preventDefault();
                       gameRef.current.touch.switchWeapon = true;
@@ -3011,6 +3064,7 @@
                   {/* Jump Button */}
                   <div
                     className="absolute right-28 bottom-4 w-20 h-20 pointer-events-auto"
+                    style={{ touchAction: 'none' }}
                     onTouchStart={(e) => {
                       e.preventDefault();
                       if (!gameRef.current.player.isJumping) {
@@ -3028,6 +3082,7 @@
                   {/* Shoot Button */}
                   <div
                     className="absolute right-4 bottom-4 w-20 h-20 pointer-events-auto"
+                    style={{ touchAction: 'none' }}
                     onTouchStart={(e) => {
                       e.preventDefault();
                       gameRef.current.touch.shoot = true;


### PR DESCRIPTION
- Add CSS to prevent touch scrolling, text selection, and overscroll bounce
- Add touch-action: none to all virtual controls (joystick, buttons)
- Adjust canvas spacing for touch devices (250px vs 200px for desktop)
- Add mobile audio unlock mechanism for iOS/mobile browser compatibility
- Extract magic numbers to CANVAS_SIZING constants
- All changes scoped to touch/mobile, desktop gameplay unaffected